### PR TITLE
Fix favorite button css in tutorial step-4.

### DIFF
--- a/docs/start/tutorial/step-4.md
+++ b/docs/start/tutorial/step-4.md
@@ -118,16 +118,16 @@ core-icon-button {
   position: absolute;
   top: 3px;
   right: 3px;
-  fill: #636363;
+  color: #636363;
 }
 :host([favorite]) core-icon-button {
-  fill: #da4336;
+  color: #da4336;
 }</strong>
 &lt;/style>
 </pre>
   <aside>
     <ul>
-      <li><code>fill</code> 属性设置了 icon 的填充色。</li>
+      <li><code>color</code> 属性设置了 icon 的填充色。</li>
       <li><code>:host([favorite]) core-icon-button</code> 选择器设置的是 custom element 的 <code>favorite</code> 属性被设定时的填充色。</li>
     </ul>
   </aside>


### PR DESCRIPTION
上次上海 Polymer DevFest 使用 polymer 中文文档做 codelab 时有朋友发现了这个问题。

官方文档 favirote button 的 CSS 是 color
将中文文档中的 fill 改为 color

另外也 grep 了一下其他的文件，发现还有两个地方使用了 fill 这个属性，不过官方文档那里也使用的 fill，暂时没有修改。
